### PR TITLE
Añadir selector de mercado para el inicio de sesión

### DIFF
--- a/custom_components/kobold_vr7/const.py
+++ b/custom_components/kobold_vr7/const.py
@@ -2,6 +2,7 @@ DOMAIN = "kobold_vr7"
 CONF_EMAIL = "email"
 CONF_OTP = "otp"
 CONF_ID_TOKEN = "id_token"
+CONF_MARKET = "market"
 ORBITAL_HOST = "https://orbital.ksecosys.com"
 AUTH_HOST = "https://mykobold.eu.auth0.com"
 COMPANION_HOST = "https://api-2-prod.companion.kobold.vorwerk.com"
@@ -13,6 +14,36 @@ MOBILE_APP_OS_VERSION = "11"
 MOBILE_APP_USER_AGENT = "okhttp/5.1.0"
 MOBILE_APP_ACCEPT_ENCODING = "gzip"
 SIGNAL_ROBOT_BATTERY = "kobold_vr7_battery"
+
+# Mercados soportados y el idioma asociado que necesitan las APIs
+DEFAULT_MARKET = "es"
+SUPPORTED_MARKETS = {
+    "de": {
+        "label": "Alemania",
+        "locale": "de",
+        "accept_language": "de-DE",
+    },
+    "es": {
+        "label": "España",
+        "locale": "es",
+        "accept_language": "es-ES",
+    },
+    "fr": {
+        "label": "Francia",
+        "locale": "fr",
+        "accept_language": "fr-FR",
+    },
+    "it": {
+        "label": "Italia",
+        "locale": "it",
+        "accept_language": "it-IT",
+    },
+    "en": {
+        "label": "Reino Unido / Internacional",
+        "locale": "en",
+        "accept_language": "en-EN",
+    },
+}
 
 # Descripciones amigables para los códigos de error recibidos por WebSocket
 ERROR_CODE_DESCRIPTIONS = {

--- a/custom_components/kobold_vr7/translations/de.json
+++ b/custom_components/kobold_vr7/translations/de.json
@@ -5,7 +5,8 @@
         "title": "Mit Kobold verbinden",
         "description": "Geben Sie Ihre E-Mail-Adresse ein, um den OTP-Code zu erhalten.",
         "data": {
-          "email": "E-Mail"
+          "email": "E-Mail",
+          "market": "Land"
         }
       },
       "otp": {

--- a/custom_components/kobold_vr7/translations/en.json
+++ b/custom_components/kobold_vr7/translations/en.json
@@ -5,7 +5,8 @@
         "title": "Connect with Kobold",
         "description": "Enter your email to receive the OTP code.",
         "data": {
-          "email": "Email"
+          "email": "Email",
+          "market": "Country"
         }
       },
       "otp": {

--- a/custom_components/kobold_vr7/translations/es.json
+++ b/custom_components/kobold_vr7/translations/es.json
@@ -5,7 +5,8 @@
         "title": "Conectar con Kobold",
         "description": "Ingresa tu correo electrónico para recibir el código OTP.",
         "data": {
-          "email": "Correo electrónico"
+          "email": "Correo electrónico",
+          "market": "País"
         }
       },
       "otp": {


### PR DESCRIPTION
## Summary
- incorporar un selector de mercado europeo en el flujo de configuración para almacenar el idioma correcto
- centralizar los mercados soportados y su cabecera Accept-Language en constantes reutilizables
- reutilizar el idioma del mercado en las llamadas al Companion y en el WebSocket, actualizando las traducciones del formulario

## Testing
- python -m compileall custom_components/kobold_vr7

------
https://chatgpt.com/codex/tasks/task_e_68ff6e0c74f48327bcc06f4f5aeab96b