### PR TITLE
fix user_api_client headers for german market

### DIFF
--- a/custom_components/kobold_vr7/api/user_api_client.py
+++ b/custom_components/kobold_vr7/api/user_api_client.py
@@ -35,6 +35,11 @@ class UserApiClient:
 
     async def validate_otp(self, email: str, otp: str) -> ValidateOtpResponse:
         url = self.host + self.path_validate_otp
+        # fix source for the german market
+        if self.lanugage != "de":
+            source = "vorwerk_auth0_international"
+        else:
+            source = "vorwerk_auth0"
         payload = {
             "client_id": self.client_id,
             "scope": "openid profile email",
@@ -44,7 +49,7 @@ class UserApiClient:
             "realm": "email",
             "platform": "android",
             "locale": self.language,  # Usando el idioma configurado
-            "source": "vorwerk_auth0_international",
+            "source": source,
         }
         response = await self._make_request("POST", url, json=payload)
         return ValidateOtpResponse(**response)


### PR DESCRIPTION
This fixes #20 for the german market.

It is created under the assumption that all other markets are using "vorwerk_auth0_international" and that you get the language from the country selection during setup.
